### PR TITLE
Release 0.5.1

### DIFF
--- a/charts/lucenia/Chart.yaml
+++ b/charts/lucenia/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the lucenia app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.0
+version: 0.5.1
 
 # This is the version number of Lucenia being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.5.0"
+appVersion: "0.5.1"
 
 maintainers:
   - name: Lucenia


### PR DESCRIPTION
This PR updates the Lucenia helm chart to version `0.5.1` and appVersion to `0.5.1`.

Addresses https://github.com/lucenia/skylite/issues/566